### PR TITLE
config: run workflows on `main` additionally to `master`

### DIFF
--- a/config/workflows/codeql.yml
+++ b/config/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master", "stable-*" ]
+    branches: [ "master", "main", "stable-*" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "main" ]
   schedule:
     - cron: '24 18 * * 3'
 

--- a/config/workflows/detectNewJavaFiles.yml
+++ b/config/workflows/detectNewJavaFiles.yml
@@ -2,7 +2,7 @@ name: "Detect new java files"
 
 on:
   pull_request:
-    branches: [ master, stable-* ]
+    branches: [ master, main, stable-* ]
 
 permissions: read-all
 


### PR DESCRIPTION
`main` is the default branch for android-common, and should be the default for new repos too.

Whenever we eventually move the other repos to use `main`, we can drop `master` completely

