### PR TITLE
codeql: Add swapspace to avoid OOM

### DIFF
--- a/config/workflows/codeql.yml
+++ b/config/workflows/codeql.yml
@@ -1,3 +1,4 @@
+# synced from @nextcloud/android-config
 name: "CodeQL"
 
 on:
@@ -26,6 +27,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+    - name: Set Swap Space
+      uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c #v1.0
+      with:
+          swap-size-gb: 10
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:


### PR DESCRIPTION
CodeQL is randomly failing due to OOM errors, and there is no way to limit the memory used by the codeQL action.

To avoid this we simply add a swapfile, which leads to the runs completing fine.

Tested in https://github.com/nextcloud/android/pull/11163
