### PR TITLE
Setup Renovatebot for updating workflows

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,10 @@
     ":disableDependencyDashboard",
     "schedule:daily"
   ],
+  "timezone": "Europe/Berlin",
+  "labels": [
+    "dependencies"
+  ],
   "enabledManagers": [
     "github-actions"
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "helpers:pinGitHubActionDigests",
+    ":disableDependencyDashboard",
+    "schedule:daily"
+  ],
+  "enabledManagers": [
+    "github-actions"
+  ],
+  "github-actions": {
+    "fileMatch": [
+      "^(config\\/workflows)\\/[^/]+\\.ya?ml$"
+    ]
+  }
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,19 @@
+name: Renovate
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.3.0
+      - name: Run Renovate
+        uses: renovatebot/github-action@v34.82.0
+        with:
+          configurationFile: .github/renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
Reference: https://docs.renovatebot.com/getting-started/running/#github-action

Currently configured to:
 - Update GH actions and pin them by hash
 - Run once a day
 - Disable the global "dependency dashboard" issue that it would otherwise create
 - Update workflows both in .github/workflows (does this by default) and our synced ones (config/workflows)

Fixes #13
