### PR TITLE
Sync dependabot config

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -8,3 +8,5 @@ group:
   files:
     - source: config/workflows/
       dest: .github/workflows/
+    - source: config/dependabot.yml
+      dest: .github/dependabot.yml

--- a/config/dependabot.yml
+++ b/config/dependabot.yml
@@ -1,0 +1,18 @@
+# synced from @nextcloud/android-config
+version: 2
+updates:
+    -   package-ecosystem: "github-actions"
+        directory: "/"
+        schedule:
+            interval: "weekly"
+    -   package-ecosystem: gradle
+        directory: "/"
+        schedule:
+            interval: daily
+            time: "03:00"
+            timezone: Europe/Paris
+        rebase-strategy: "disabled"
+        open-pull-requests-limit: 10
+        labels:
+            - 3. to review
+            - dependencies

--- a/config/workflows/autoApproveSync.yml
+++ b/config/workflows/autoApproveSync.yml
@@ -1,3 +1,4 @@
+# synced from @nextcloud/android-config
 name: Auto approve
 on:
   pull_request_target:


### PR DESCRIPTION
Now that the labels are the same between all projects, we can share the dependabot config.

@mahibi The only important difference here is that Talk has some `ignore` blocks for jackrabbit-webdav;
just let Dependabot open a PR for them and tell it to ignore that dependency with bot commands.
