### PR TITLE
file sync: sync only once per day

### DIFF
--- a/.github/workflows/file-sync.yml
+++ b/.github/workflows/file-sync.yml
@@ -1,8 +1,7 @@
 name: Sync Files
 on:
-  push:
-    branches:
-      - main
+  cron:
+    - "0 2 * * *"
   workflow_dispatch:
 jobs:
   sync:

--- a/.github/workflows/file-sync.yml
+++ b/.github/workflows/file-sync.yml
@@ -1,7 +1,7 @@
 name: Sync Files
 on:
-  cron:
-    - "0 2 * * *"
+  schedule:
+    - cron: "0 2 * * *"
   workflow_dispatch:
 jobs:
   sync:


### PR DESCRIPTION
This should avoid multiple automated updates to sync PRs/ multiple sync PRs when we are actively working on this repo.

Please note that this does not prevent us from triggering sync manually (it has a `workflow_dispatch` trigger)
from the Actions tab on github, in case of need.