### PR TITLE
Sync dependabot auto-approve workflow

### DIFF
--- a/config/workflows/autoApproveDependabot.yml
+++ b/config/workflows/autoApproveDependabot.yml
@@ -1,0 +1,30 @@
+# synced from @nextcloud/android-config
+name: Dependabot
+
+on:
+  pull_request_target:
+    branches:
+      - main
+      - master
+      - stable-*
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-approve-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  auto-approve:
+    name: Auto approve
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      # needed to approve the PR
+      pull-requests: write
+
+    steps:
+      - uses: hmarr/auto-approve-action@de8ae18c173c131e182d4adf2c874d8d2308a85b # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Was going to add this to Notes, figured out it should be better synced to all repos.

This is adapted from https://github.com/nextcloud/.github/blob/master/workflow-templates/dependabot-approve-merge.yml,
includes concurrency config and more granular permissions

