### PR TITLE
Minor fixes for auto-approve workflows

### DIFF
--- a/config/workflows/autoApproveDependabot.yml
+++ b/config/workflows/autoApproveDependabot.yml
@@ -1,5 +1,5 @@
 # synced from @nextcloud/android-config
-name: Dependabot
+name: Auto approve dependabot
 
 on:
   pull_request_target:
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   auto-approve:
-    name: Auto approve
+    name: Auto approve dependabot
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     permissions:

--- a/config/workflows/autoApproveSync.yml
+++ b/config/workflows/autoApproveSync.yml
@@ -1,5 +1,5 @@
 # synced from @nextcloud/android-config
-name: Auto approve
+name: Auto approve sync
 on:
   pull_request_target:
     branches:
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   auto-approve:
+    name: Auto approve sync
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@de8ae18c173c131e182d4adf2c874d8d2308a85b # v3.1.0

--- a/config/workflows/autoApproveSync.yml
+++ b/config/workflows/autoApproveSync.yml
@@ -22,8 +22,8 @@ jobs:
   auto-approve:
     name: Auto approve sync
     runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'sync') && github.actor == 'nextcloud-android-bot' }}
     steps:
       - uses: hmarr/auto-approve-action@de8ae18c173c131e182d4adf2c874d8d2308a85b # v3.1.0
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'sync') && github.actor == 'nextcloud-android-bot' }}
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/config/workflows/autoApproveSync.yml
+++ b/config/workflows/autoApproveSync.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - master
       - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+
+concurrency:
+  group: sync-approve-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
As explained in https://github.com/nextcloud/android-library/pull/1060#issuecomment-1423822136, the sync
action adds the label *after* opening the PR, so when this workflow runs the label isn't there yet,
and the auto-approve action will be skipped.

This fixes that by also running this workflow when the PR is labeled. `opened`, `reopened` and `synchronize` are the default triggers, I  just added `labeled`

Also added a concurrency group to avoid running this in parallel.

