### PR TITLE
stale workflow: remove the 'needs info' label when no longer stale

### DIFF
--- a/config/workflows/stale.yml
+++ b/config/workflows/stale.yml
@@ -26,3 +26,4 @@ jobs:
             Please take a look again and update the issue with new details,
             otherwise the issue will be automatically closed in 2 weeks. Thank you!
           exempt-all-pr-milestones: true
+          labels-to-remove-when-unstale: 'needs info'


### PR DESCRIPTION
When no longer stale, also remove the 'needs info' label automatically.

Addresses https://github.com/nextcloud/android/issues/9153#issuecomment-1863610566