### PR TITLE
fix(autoApproveSync): Cleanup triggering by labels

### DIFF
--- a/config/workflows/autoApproveSync.yml
+++ b/config/workflows/autoApproveSync.yml
@@ -11,7 +11,6 @@ on:
       - master
       - main
     types:
-      - opened
       - reopened
       - synchronize
       - labeled
@@ -27,7 +26,7 @@ jobs:
   auto-approve:
     name: Auto approve sync
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'sync') && github.actor == 'nextcloud-android-bot' }}
+    if: ${{ github.event.pull_request.label.name == 'sync' && github.actor == 'nextcloud-android-bot' }}
     steps:
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         with:

--- a/config/workflows/autoApproveSync.yml
+++ b/config/workflows/autoApproveSync.yml
@@ -26,7 +26,7 @@ jobs:
   auto-approve:
     name: Auto approve sync
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.label.name == 'sync' && github.actor == 'nextcloud-android-bot' }}
+    if: ${{ github.event.label.name == 'sync' && github.actor == 'nextcloud-android-bot' }}
     steps:
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         with:


### PR DESCRIPTION
WIP: Hmm, there's still a bit more needed here. Will pick this up another time. Don't have time today. I'm sure it'll annoy be enough again in the future to motivate a revisit. :)

This workflow is creating lots of unnecessary noise and runs that stomp on themselves. I think this will fix the two most common interactions:

- PR is opened (lacks labels at this point so don't bother)
- PR gets multiple labels added to it:
  - scenario one (non-bot): none of which are `sync` so move on
  - scenario two (bot): one of the labels is sync so do the approval this workflow exists for

---

* Don't bother to trigger on `opened` since we won't have a label until PR is `labeled`
* Don't trigger every time *any* label is added
  - This was causing overlapping requests that were multiplied by how many labels are attached to a given PR