### PR TITLE
enable to use self hosted runners by using ubuntu-latest

### DIFF
--- a/config/workflows/analysis.yml
+++ b/config/workflows/analysis.yml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2023 Tobias Kaminsky <tobias@kaminsky.me>
 # SPDX-FileCopyrightText: 2023 Andy Scherzinger <info@andy-scherzinger.de>
 # SPDX-FileCopyrightText: 2023 Josh Richards <josh.t.richards@gmail.com>
+# SPDX-FileCopyrightText: 2025 Marcel Hibbe <dev@mhibbe.de>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 name: "Analysis"
@@ -24,7 +25,7 @@ concurrency:
 
 jobs:
     analysis:
-        runs-on: ubuntu-24.04
+        runs-on: ubuntu-latest
         steps:
             -   name: Setup variables
                 id: get-vars

--- a/config/workflows/codeql.yml
+++ b/config/workflows/codeql.yml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2023-2024 Andy Scherzinger <info@andy-scherzinger.de>
 # SPDX-FileCopyrightText: 2022 Tobias Kaminsky <tobias@kaminsky.me>
 # SPDX-FileCopyrightText: 2022 Álvaro Brey <alvaro@alvarobrey.com>
+# SPDX-FileCopyrightText: 2025 Marcel Hibbe <dev@mhibbe.de>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 name: "CodeQL"
@@ -22,7 +23,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
@@ -35,6 +36,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set Swap Space
+        if: runner.environment == 'github-hosted'
         uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c # v1.0
         with:
           swap-size-gb: 10


### PR DESCRIPTION
also see https://github.com/nextcloud/talk-android/pull/4744 where the configs were tested for android talk (Both selfhosted runners and github runners succeeded)

---

By using ubuntu-latest, the self hosted runners can be used which should speed up the build process (by avoiding waiting in a queue for github runners)

By adding
`if: runner.environment == 'github-hosted'`
the following error about Set Swap State is avoided when running on selfhosted servers:

```
    Run pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c
    Run echo "Memory and swap:"
    Memory and swap:
                   total        used        free      shared  buff/cache   available
    Mem:           6.5Gi       273Mi       6.0Gi        54Mi       300Mi       6.3Gi
    Swap:             0B          0B          0B

    Run export SWAP_FILE=$(swapon --show=NAME | tail -n 1)
    swapoff: bad usage
    Try 'swapoff --help' for more information.
    Error: Process completed with exit code 16.
```